### PR TITLE
Changes for supporting elasticpress 5.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ etc/ENV
 etc-kube
 docker-compose.yml
 composer.lock
-wordpress
 .DS_Store
 .docker-sync
 .idea

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -8,7 +8,7 @@ if [[ $GOOGLE_GIT_TOKEN ]]; then
   set +e
 
   # Add gcloud
-  echo "machine source.developers.google.com login jeff@proudcity.com password ${GOOGLE_GIT_TOKEN}" >> $HOME/.netrc
+  echo "machine source.developers.google.com login jeff@proudcity.com password ${GOOGLE_GIT_TOKEN}" >> "$HOME"/.netrc
 
   # making sure google repositories exist
   #until $( curl --output /dev/null --silent --head --fail https://source.developers.google.com ); do
@@ -42,8 +42,8 @@ if [[ $GOOGLE_GIT_TOKEN ]]; then
     export IFS=","
     for s in $WORDPRESS_THEMES; do
       cmd="git clone ${s}"
-      eval $cmd
-      echo "Adding theme repo: ${s} in `pwd`"
+      eval "$cmd"
+      echo "Adding theme repo: ${s} in $(pwd)"
     done
   fi
 
@@ -53,8 +53,8 @@ if [[ $GOOGLE_GIT_TOKEN ]]; then
     export IFS=","
     for s in $WORDPRESS_PLUGINS; do
       cmd="git clone ${s}"
-      eval $cmd
-      echo "Adding plugin repo: ${s} in `pwd`"
+      eval "$cmd"
+      echo "Adding plugin repo: ${s} in $(pwd)"
     done
   fi
 
@@ -64,8 +64,8 @@ if [[ $GOOGLE_GIT_TOKEN ]]; then
     export IFS=","
     for s in $WORDPRESSORG_PLUGINS; do
       cmd="curl -O -L http://downloads.wordpress.org/plugin/${s}.zip && unzip ${s}.zip && rm ${s}.zip"
-      eval $cmd
-      echo "Adding WP.org plugin: ${s} in `pwd`"
+      eval "$cmd"
+      echo "Adding WP.org plugin: ${s} in $(pwd)"
     done
   fi
 
@@ -135,10 +135,22 @@ export UPLOAD_MAX_FILESIZE=${UPLOAD_MAX_FILESIZE:-"25M"}
 
 # Ensure that we have the latest wp-rocket con
 echo "Importing WP Rocket configuration"
-wp rocket import --allow-root /app/bin/wp-rocket.json
+# wp rocket import --allow-root /app/bin/wp-rocket.json
 
 # enable redis requires the Redis Cache plugin to be active
 echo "Enabling Redis"
-wp redis enable --allow-root
+# wp redis enable --allow-root
 
 exec "$@"
+
+# #!/bin/sh
+# # set -e
+
+# # first arg is `-f` or `--some-option`
+# if [ "${1#-}" != "$1" ]; then
+# 	set -- apache2-foreground "$@"
+# fi
+
+# # exec "$@"
+# cd /app/wordpress
+# apache2-foreground

--- a/bin/pc
+++ b/bin/pc
@@ -225,7 +225,7 @@ class Pc extends Bin {
      */
     public function devDb() {
 
-        passthru('docker exec -it $(docker ps -aq --filter="name=wpproudcity_wordpress_1") mysql -uwordpress -pwordpress wordpress');
+        passthru('docker exec -it $(docker ps -aq --filter="name=wpproudcity_wordpress_1") mysql -uroot -pHELLO wordpress');
     }
 
     /**
@@ -288,7 +288,7 @@ class Pc extends Bin {
 
         $this->printLine('Importing ' . $this->arg1, 'yellow');
         $this->pc('dev wp db import ' . $this->arg1);
-        $newurl = 'http://localhost:8888';
+        $newurl = 'http://localhost:8000';
         $oldurl = trim($this->pc('dev wp option get siteurl', true));
         $this->pc('dev wp search-replace "'. $oldurl .'" "'. $newurl .'"');
         $this->pc('dev wp plugin uninstall --deactivate w3-total-cache elasticpress');

--- a/composer.json
+++ b/composer.json
@@ -249,11 +249,11 @@
       "package": {
         "name": "proudcity/wp-proud-search-elastic",
         "type": "wordpress-plugin",
-        "version": "2024.06.20.0000",
+        "version": "2024.08.13.0000",
         "source": {
           "type": "git",
           "url": "https://github.com/proudcity/wp-proud-search-elastic.git",
-          "reference": "2024.06.20.0000"
+          "reference": "2024.08.13.0000"
         }
       }
     },
@@ -547,7 +547,7 @@
     "proudcity/wp-proud-core": "2024.09.04.1019",
     "proudcity/wp-proud-agency": "2024.08.19.1443",
     "proudcity/wp-proud-search": "2024.03.27.1000",
-    "proudcity/wp-proud-search-elastic": "2024.06.20.0000",
+    "proudcity/wp-proud-search-elastic": "2024.08.13.0000",
     "proudcity/wp-proud-payment": "1.134.0",
     "proudcity/wp-proud-document": "2023.08.30.0725",
     "proudcity/wp-proud-location": "2023.11.28.1151",

--- a/composer.json
+++ b/composer.json
@@ -249,11 +249,11 @@
       "package": {
         "name": "proudcity/wp-proud-search-elastic",
         "type": "wordpress-plugin",
-        "version": "2024.08.13.0000",
+        "version": "2024.09.13.0000",
         "source": {
           "type": "git",
           "url": "https://github.com/proudcity/wp-proud-search-elastic.git",
-          "reference": "2024.08.13.0000"
+          "reference": "2024.09.13.0000"
         }
       }
     },
@@ -547,7 +547,7 @@
     "proudcity/wp-proud-core": "2024.09.04.1019",
     "proudcity/wp-proud-agency": "2024.08.19.1443",
     "proudcity/wp-proud-search": "2024.03.27.1000",
-    "proudcity/wp-proud-search-elastic": "2024.08.13.0000",
+    "proudcity/wp-proud-search-elastic": "2024.09.13.0000",
     "proudcity/wp-proud-payment": "1.134.0",
     "proudcity/wp-proud-document": "2023.08.30.0725",
     "proudcity/wp-proud-location": "2023.11.28.1151",

--- a/composer.json
+++ b/composer.json
@@ -536,7 +536,7 @@
     "wpackagist-plugin/font-awesome": "4.5.0",
     "wpackagist-plugin/wordpress-faq-manager": "2.0.2",
     "wpackagist-plugin/redis-cache": "2.5.3",
-    "wpackagist-plugin/elasticpress": "2.8.2",
+    "wpackagist-plugin/elasticpress": "^5.0.1",
     "wpackagist-plugin/wp-stateless": "4.0.4",
     "wpackagist-plugin/fix-alt-text": "1.9.0",
     "proudcity/mce-table-buttons": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -536,7 +536,7 @@
     "wpackagist-plugin/font-awesome": "4.5.0",
     "wpackagist-plugin/wordpress-faq-manager": "2.0.2",
     "wpackagist-plugin/redis-cache": "2.5.3",
-    "wpackagist-plugin/elasticpress": "5.0.3",
+    "wpackagist-plugin/elasticpress": "5.1.3",
     "wpackagist-plugin/wp-stateless": "4.0.4",
     "wpackagist-plugin/fix-alt-text": "1.9.0",
     "proudcity/mce-table-buttons": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -249,11 +249,11 @@
       "package": {
         "name": "proudcity/wp-proud-search-elastic",
         "type": "wordpress-plugin",
-        "version": "2024.03.27.0955",
+        "version": "2024.06.20.0000",
         "source": {
           "type": "git",
           "url": "https://github.com/proudcity/wp-proud-search-elastic.git",
-          "reference": "2024.03.27.0955"
+          "reference": "2024.06.20.0000"
         }
       }
     },
@@ -547,7 +547,7 @@
     "proudcity/wp-proud-core": "2024.09.04.1019",
     "proudcity/wp-proud-agency": "2024.08.19.1443",
     "proudcity/wp-proud-search": "2024.03.27.1000",
-    "proudcity/wp-proud-search-elastic": "2024.03.27.0955",
+    "proudcity/wp-proud-search-elastic": "2024.06.20.0000",
     "proudcity/wp-proud-payment": "1.134.0",
     "proudcity/wp-proud-document": "2023.08.30.0725",
     "proudcity/wp-proud-location": "2023.11.28.1151",

--- a/composer.json
+++ b/composer.json
@@ -536,7 +536,7 @@
     "wpackagist-plugin/font-awesome": "4.5.0",
     "wpackagist-plugin/wordpress-faq-manager": "2.0.2",
     "wpackagist-plugin/redis-cache": "2.5.3",
-    "wpackagist-plugin/elasticpress": "^5.0.1",
+    "wpackagist-plugin/elasticpress": "5.0.3",
     "wpackagist-plugin/wp-stateless": "4.0.4",
     "wpackagist-plugin/fix-alt-text": "1.9.0",
     "proudcity/mce-table-buttons": "dev-master",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,12 +95,13 @@ services:
       - 3306:3306
   # Uncomment for elasticsearch
   elasticsearch:
-    platform: linux/amd64 # added
+    platform: linux/x86_64 # added
     container_name: elasticsearch
     # build: ./services/docker-elasticsearch-test
     # image: gcr.io/proudcity-1184/docker-elasticsearch-kubernetes:5.3.2
     # image: elastic/elasticsearch:5.3.2
-    image: bitnami/elasticsearch:5.6.4-r0
+    # image: bitnami/elasticsearch:5.6.4-r0
+    image: bitnami/elasticsearch:6.8.23-debian-10-r77
     environment:
       - ELASTICSEARCH_PLUGINS=ingest-attachment
       - ELASTICSEARCH_SKIP_TRANSPORT_TLS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,14 @@ services:
       - db
       # Uncomment for elasticsearch
       - elasticsearch
-      # - elasticdocapi
+      - elasticdocapi
     # Uncomment for elasticsearch
     links:
       - 'elasticsearch:elasticsearchdocs.elasticsearch'
-    #   - 'elasticdocapi:docsapi.elasticsearch'
+      - 'elasticdocapi:docsapi.elasticsearch'
     command: ['apache2-foreground']
     entrypoint: /app/bin/entrypoint.sh
-    image: gcr.io/proudcity-1184/wp-proudcity:staging-4d359a863c029f44f59649b0b28846747f081441
+    image: gcr.io/proudcity-1184/wp-proudcity:staging-771560f14403116e7c685eecd5229f1aa1c27c7e
     # build:
     #   context: .
     #   dockerfile: Dockerfile
@@ -69,8 +69,8 @@ services:
       # ELASTICSEARCH_HOST:
       ELASTICSEARCH_HOST: 'elasticsearchdocs.elasticsearch'
       # Uncomment for elasticsearch
-      ELASTICSEARCH_DOCS_HOST:
-      # ELASTICSEARCH_DOCS_HOST: 'docsapi.elasticsearch'
+      # ELASTICSEARCH_DOCS_HOST:
+      ELASTICSEARCH_DOCS_HOST: 'docsapi.elasticsearch'
       UPLOAD_MAX_FILESIZE: 25M
       # GOOGLE_GIT_TOKEN: # set this to download private repos and $WORDPRESS_PLUGINS in entrypoint.sh
       # WORDPRESSORG_PLUGINS:  # These plugins (csv of slugs) will be downloaded on container start (requires $GOOGLE_GIT_TOKEN)
@@ -93,54 +93,67 @@ services:
       MYSQL_PASSWORD: wordpress
     ports:
       - 3306:3306
-  # # Uncomment for elasticsearch
-  # redis:
-  #   image: redis
-  #   restart: always
-  #   networks:
-  #     - es-net
-  #   ports:
-  #     - 6379:6379
-  # # Uncomment for elasticsearch
-  # elasticdocapi:
-  #   build: ./proud-elastic-doc-api
-  #   restart: always
-  #   ports:
-  #     - 8085:80
-  #   depends_on:
-  #     - redis
-  #   links:
-  #     - 'redis:elasticdocsapiredis.elasticsearch'
-  #     - 'elasticsearch:elasticsearchdocs.elasticsearch'
-  #   networks:
-  #     - es-net
-  #   environment:
-  #     PORT: 80
-  #     ELASTIC: 'elasticsearchdocs.elasticsearch'
-  #     REDIS: 'elasticdocsapiredis.elasticsearch'
-  #     REDISPORT: 6379
-  # # Uncomment for elasticsearch
+  # Uncomment for elasticsearch
   elasticsearch:
+    platform: linux/amd64 # added
     container_name: elasticsearch
-    build: ./services/docker-elasticsearch-new
+    # build: ./services/docker-elasticsearch-test
     # image: gcr.io/proudcity-1184/docker-elasticsearch-kubernetes:5.3.2
+    # image: elastic/elasticsearch:5.3.2
+    image: bitnami/elasticsearch:5.6.4-r0
     environment:
+      - ELASTICSEARCH_PLUGINS=ingest-attachment
+      - ELASTICSEARCH_SKIP_TRANSPORT_TLS=true
+      - ELASTICSEARCH_LOCK_ALL_MEMORY=true
+      - ELASTICSEARCH_IS_DEDICATED_NODE=true
+      - ELASTICSEARCH_NODE_TYPE=master
       - node.name=elasticsearch
       - cluster.name=es-docker-cluster
       # - discovery.seed_hosts=es02,es03
       - cluster.initial_master_nodes=elasticsearch
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+      - discovery.type=single-node
+      # - es.enforce.bootstrap.checks=false
     ulimits:
       memlock:
         soft: -1
         hard: -1
     volumes:
       - data01:/usr/share/elasticsearch/data
+      # - data01:/bitnami/elasticsearch/data
+      - ./services/docker-elasticsearch/config/elasticsearch.yml:/bitnami/elasticsearch/conf/elasticsearch_custom.yml
     ports:
       - 9200:9200
     networks:
       - es-net
+  # Uncomment for elasticsearch
+  redis:
+    image: redis
+    restart: always
+    networks:
+      - es-net
+    ports:
+      - 6379:6379
+  # Uncomment for elasticsearch
+  elasticdocapi:
+    # build: ./services/proudcity-elastic-docs-api
+    image: gcr.io/proudcity-1184/proud-elastic-doc-api:kubernetes.6
+    restart: always
+    ports:
+      - 8085:80
+    depends_on:
+      - redis
+    links:
+      - 'redis:elasticdocsapiredis.elasticsearch'
+      - 'elasticsearch:elasticsearchdocs.elasticsearch'
+    networks:
+      - es-net
+    environment:
+      PORT: 80
+      ELASTIC: 'elasticsearchdocs.elasticsearch'
+      REDIS: 'elasticdocsapiredis.elasticsearch'
+      REDISPORT: 6379
 
 # Uncomment for elasticsearch
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,22 @@ services:
     container_name: wpproudcity_wordpress_1
     depends_on:
       - db
-    image: gcr.io/proudcity-1184/wp-proudcity:master-73e8c4ea20c9c7e52325d8ad659f209932fc155e
+      # Uncomment for elasticsearch
+      - elasticsearch
+      # - elasticdocapi
+    # Uncomment for elasticsearch
+    links:
+      - 'elasticsearch:elasticsearchdocs.elasticsearch'
+    #   - 'elasticdocapi:docsapi.elasticsearch'
+    command: ['apache2-foreground']
+    entrypoint: /app/bin/entrypoint.sh
+    image: gcr.io/proudcity-1184/wp-proudcity:staging-4d359a863c029f44f59649b0b28846747f081441
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     volumes:
       #- wp-proudcity-sync:/app/wordpress:nocopy # nocopy is important
+      - ./bin:/app/bin
       - ./wordpress:/app/wordpress
       # Exclude node_modules dirs for better performance
       - ./node_modules:/app/wordpress/wp-content/plugins/wp-proud-admin/node_modules
@@ -15,7 +28,11 @@ services:
       - ./node_modules:/app/wordpress/wp-content/themes/wp-proud-theme-intranet/node_modules
     tty: true
     ports:
-      - "8000:80"
+      - '8000:80'
+    # Uncomment for elasticsearch
+    networks:
+      - default
+      - es-net
     environment:
       AUTH_REQUIRED:
       AUTH_USERNAME:
@@ -38,29 +55,37 @@ services:
       STATELESS_MEDIA_KEY_FILE_PATH:
       STATELESS_MEDIA_BUCKET:
       STATELESS_MEDIA_DIRECTORY:
-      STATELESS_MEDIA_CACHE_BUSTING: "1" # defaults to false
-      REDIS_SESSION: "false" # no longer supported
-      PHP_MEMORY_LIMIT: 256M
+      STATELESS_MEDIA_CACHE_BUSTING: '1' # defaults to false
+      REDIS_SESSION: 'false' # no longer supported
+      # @TODO set back to 256
+      PHP_MEMORY_LIMIT: 2048M
       SMTP_HOST:
       SMTP_PASS:
       SMTP_USER:
       BLOCK_LOGIN:
       WP_REDIS_BACKEND_HOST:
       WP_REDIS_BACKEND_AUTH:
+      # Uncomment for elasticsearch
+      # ELASTICSEARCH_HOST:
+      ELASTICSEARCH_HOST: 'elasticsearchdocs.elasticsearch'
+      # Uncomment for elasticsearch
       ELASTICSEARCH_DOCS_HOST:
-      ELASTICSEARCH_HOST:
+      # ELASTICSEARCH_DOCS_HOST: 'docsapi.elasticsearch'
       UPLOAD_MAX_FILESIZE: 25M
       # GOOGLE_GIT_TOKEN: # set this to download private repos and $WORDPRESS_PLUGINS in entrypoint.sh
       # WORDPRESSORG_PLUGINS:  # These plugins (csv of slugs) will be downloaded on container start (requires $GOOGLE_GIT_TOKEN)
       # WORDPRESS_PLUGINS:  # These plugins (git repo) will be downloaded on container start (requires $GOOGLE_GIT_TOKEN)
       # WORDPRESS_THEMES:  # These themes (git repo) will be downloaded on container start (requires $GOOGLE_GIT_TOKEN)
-            #WORDPRESS_PLUGINS: "https://source.developers.google.com/p/proudcity-1184/r/wp-proud-sr-ca-widgets,https://github.com/SenecaSystems/romulus-wordpress-form.git,https://github.com/proudcity/wp-proud-directory.git"
-            #WORDPRESSORG_PLUGINS: "buddypress,bp-default-data,buddypress-edit-activity,bbpress,buddydrive"
-            #WORDPRESS_THEMES: "https://source.developers.google.com/p/proudcity-1184/r/wp-proud-sr-ca-theme"
+      # WORDPRESS_PLUGINS: "https://source.developers.google.com/p/proudcity-1184/r/wp-proud-sr-ca-widgets,https://github.com/SenecaSystems/romulus-wordpress-form.git,https://github.com/proudcity/wp-proud-directory.git"
+      # WORDPRESSORG_PLUGINS: "buddypress,bp-default-data,buddypress-edit-activity,bbpress,buddydrive"
+      # WORDPRESS_THEMES: "https://source.developers.google.com/p/proudcity-1184/r/wp-proud-sr-ca-theme"
       WP_CACHE: 0
-      WP_DEBUG: 0
+      # @TODO set back to 0
+      WP_DEBUG: 1
   db:
     image: mariadb
+    networks:
+      - default
     environment:
       MYSQL_ROOT_PASSWORD: wordpress
       MYSQL_DATABASE: wordpress
@@ -68,6 +93,65 @@ services:
       MYSQL_PASSWORD: wordpress
     ports:
       - 3306:3306
+  # # Uncomment for elasticsearch
+  # redis:
+  #   image: redis
+  #   restart: always
+  #   networks:
+  #     - es-net
+  #   ports:
+  #     - 6379:6379
+  # # Uncomment for elasticsearch
+  # elasticdocapi:
+  #   build: ./proud-elastic-doc-api
+  #   restart: always
+  #   ports:
+  #     - 8085:80
+  #   depends_on:
+  #     - redis
+  #   links:
+  #     - 'redis:elasticdocsapiredis.elasticsearch'
+  #     - 'elasticsearch:elasticsearchdocs.elasticsearch'
+  #   networks:
+  #     - es-net
+  #   environment:
+  #     PORT: 80
+  #     ELASTIC: 'elasticsearchdocs.elasticsearch'
+  #     REDIS: 'elasticdocsapiredis.elasticsearch'
+  #     REDISPORT: 6379
+  # # Uncomment for elasticsearch
+  elasticsearch:
+    container_name: elasticsearch
+    build: ./services/docker-elasticsearch-new
+    # image: gcr.io/proudcity-1184/docker-elasticsearch-kubernetes:5.3.2
+    environment:
+      - node.name=elasticsearch
+      - cluster.name=es-docker-cluster
+      # - discovery.seed_hosts=es02,es03
+      - cluster.initial_master_nodes=elasticsearch
+      - bootstrap.memory_lock=true
+      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - es-net
+
+# Uncomment for elasticsearch
+networks:
+  default:
+    driver: bridge
+  es-net:
+    driver: bridge
+
+volumes:
+  data01:
+    driver: local
 #volumes:
 #  wp-proudcity-sync:
 #    external: true


### PR DESCRIPTION
Updates for elasticpress in order to support the move to php 8.2

`@TODO`
- [x] Get elasticpress updated
- [x] Get docker-compose working with a newer version of elasticsearch
- [x] Get attachments working with elasticpress
- [x] Get docker-compose working with https://github.com/proudcity/proudcity-elastic-docs-api
- [x] Replace / figure out kubernetes deployment of https://github.com/proudcity/docker-elasticsearch

`Tracking`
https://github.com/proudcity/wp-proudcity/issues/2428

`wp-proud-search-elastic`
https://github.com/proudcity/wp-proud-search-elastic/pull/3

Merging composer changes separately in #2603, need to get development cleaned up and updated here