### PR TITLE
Add FileToWeb PDF conversion integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.1",
+                "version": "0.1.2",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.1"
+                    "reference": "0.1.2"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.1",
+        "filetoweb/filetoweb-integration": "0.1.2",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.0",
+                "version": "0.1.1",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.0"
+                    "reference": "0.1.1"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.0",
+        "filetoweb/filetoweb-integration": "0.1.1",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.2",
+                "version": "0.1.3",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.2"
+                    "reference": "0.1.3"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.2",
+        "filetoweb/filetoweb-integration": "0.1.3",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,19 @@
         {
             "type": "package",
             "package": {
+                "name": "filetoweb/filetoweb-integration",
+                "type": "wordpress-plugin",
+                "version": "0.1.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/FileToWeb/filetoweb-integration.git",
+                    "reference": "0.1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
                 "name": "proudcity/wp-media-folder",
                 "type": "wordpress-plugin",
                 "version": "6.2.2",
@@ -495,6 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
+        "filetoweb/filetoweb-integration": "0.1.0",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.3",
+                "version": "0.1.4",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.3"
+                    "reference": "0.1.4"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.3",
+        "filetoweb/filetoweb-integration": "0.1.4",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",


### PR DESCRIPTION
## Summary
- Adds a FileToWeb MU plugin for ProudCity PDF uploads and Proud Document records.
- Queues idempotent conversions through the generic FileToWeb v1 document API.
- Polls conversion status with WP-Cron/manual admin actions.
- Replaces public media-file and attachment-page PDF links with FileToWeb HTML once ready, while preserving original PDFs in WordPress admin.
- Adds a deployment kill switch via `FTW_ENABLED=0` and documents customer rollout/backfill behavior.

## Testing
- `php -l local-mu-plugins/filetoweb-integration.php`
- `git diff --check HEAD~1..HEAD`
- End-to-end demo on https://proudcity-demo.filetoweb.com
- Verified generated FileToWeb HTML returns HTTP 200 and it is generated correctly.
- Verified public WordPress direct PDF and attachment-page links rewrite to the generated FileToWeb HTML URL once conversion is ready.
