### PR TITLE
Add FileToWeb standalone WordPress integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.1",
+                "version": "0.1.2",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.1"
+                    "reference": "0.1.2"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.1",
+        "filetoweb/filetoweb-integration": "0.1.2",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.0",
+                "version": "0.1.1",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.0"
+                    "reference": "0.1.1"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.0",
+        "filetoweb/filetoweb-integration": "0.1.1",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.2",
+                "version": "0.1.3",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.2"
+                    "reference": "0.1.3"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.2",
+        "filetoweb/filetoweb-integration": "0.1.3",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,19 @@
         {
             "type": "package",
             "package": {
+                "name": "filetoweb/filetoweb-integration",
+                "type": "wordpress-plugin",
+                "version": "0.1.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/FileToWeb/filetoweb-integration.git",
+                    "reference": "0.1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
                 "name": "proudcity/wp-media-folder",
                 "type": "wordpress-plugin",
                 "version": "6.2.2",
@@ -495,6 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
+        "filetoweb/filetoweb-integration": "0.1.0",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
             "package": {
                 "name": "filetoweb/filetoweb-integration",
                 "type": "wordpress-plugin",
-                "version": "0.1.3",
+                "version": "0.1.4",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/FileToWeb/filetoweb-integration.git",
-                    "reference": "0.1.3"
+                    "reference": "0.1.4"
                 }
             }
         },
@@ -508,7 +508,7 @@
     "require": {
         "php": ">=8.0",
         "composer/installers": "1.*",
-        "filetoweb/filetoweb-integration": "0.1.3",
+        "filetoweb/filetoweb-integration": "0.1.4",
         "johnpbloch/wordpress": "6.9.4",
         "proudcity/auth0": "3.4.1",
         "proudcity/wp-media-folder": "6.2.2",


### PR DESCRIPTION
## Summary
- Replaces the original MU-plugin proposal with the standalone `filetoweb/filetoweb-integration` WordPress plugin dependency.
- Requires FileToWeb Integration `0.1.4`, which keeps plugin code outside the ProudCity monorepo and keeps the integration suitable for broader WordPress.org/WPackagist distribution.
- Adds FileToWeb conversion support for PDF media uploads and PDF-backed Proud Document records through the standalone plugin.
- Keeps original WordPress PDFs intact and visible in admin screens.
- Rewrites public PDF links only after FileToWeb conversion is ready.
- Adds bounded manual backfill and WP-Cron polling so existing PDFs can be migrated in controlled batches.
- Adds the ProudCity Document viewer behavior requested during review: on public single Document pages, the existing Download button remains the original PDF, while the preview iframe uses FileToWeb HTML when conversion is ready.

## What Changes In This PR
- Adds a Composer package repository entry for `filetoweb/filetoweb-integration`.
- Requires `filetoweb/filetoweb-integration` `0.1.4`.
- Does not patch ProudCity theme templates or ProudCity plugin code.

## Behavior
- New PDF uploads are synced to FileToWeb idempotently.
- Repeated saves of the same file do not create duplicate conversions.
- PDF-backed Proud Documents sync to the same FileToWeb document as their attachment.
- Public page/content/widget PDF links rewrite to FileToWeb HTML once ready.
- ProudCity Document pages preserve the original PDF Download URL and replace only the preview iframe with FileToWeb HTML once ready.
- Pending, failed, non-PDF, admin, REST, feed, and editor views remain unchanged.
- The integration can be disabled by deactivating the plugin or disabling replacement in the plugin settings.

## Testing
- Standalone plugin: `composer test`
- Standalone plugin PHP syntax checks for changed files
- FileToWeb web app route tests for `/continuous`
- Demo stack verification at https://proudcity-demo.filetoweb.com
- Verified PDF media/page links rewrite to FileToWeb HTML after conversion
- Verified PDF-backed Proud Document page keeps Download as the original PDF and embeds FileToWeb HTML in the preview iframe
- Verified admin edit screen keeps the original PDF source and shows FileToWeb status/actions

## Demo URLs
- Demo site: https://proudcity-demo.filetoweb.com
- PDF-backed Proud Document viewer test: https://proudcity-demo.filetoweb.com/documents/filetoweb-proud-document-viewer-test/
- Normal page link rewrite test: https://proudcity-demo.filetoweb.com/test-page/
