### PR TITLE
Update core-plugin-update template for intuitive-cpt-order fork

### DIFF
--- a/.github/ISSUE_TEMPLATE/core-plugin-update.md
+++ b/.github/ISSUE_TEMPLATE/core-plugin-update.md
@@ -16,7 +16,9 @@ assignees: curtismchale
 
 ### Inuitive CPT caching
 
-- check to see if [our PR](https://github.com/hijiriworld/intuitive-custom-post-order/pull/64) was accepted if not modify our plugin again
+- fork updated to upstream v3.2.0 with `wp_cache_flush()` reapplied in the AJAX order-save handlers — see [proudcity/intuitive-custom-post-order#1](https://github.com/proudcity/intuitive-custom-post-order/pull/1)
+- [ ] check whether [our upstream PR hijiriworld#64](https://github.com/hijiriworld/intuitive-custom-post-order/pull/64) was merged and a release newer than 3.2.0 includes cache flushing — if so, drop the fork customization and pull upstream directly
+- verification: `diff` the fork's `intuitive-custom-post-order.php` against a pristine upstream copy; the result should show only the three `wp_cache_flush()` lines and their comments
 
 ### Simple Staff List
 


### PR DESCRIPTION
Updates the `### Inuitive CPT caching` section of the core-plugin-update issue template to reflect the new state after merging upstream v3.2.0 into our fork.

**Changes:**
- Notes that the fork is now on upstream v3.2.0 with `wp_cache_flush()` reapplied, linking [proudcity/intuitive-custom-post-order#1](https://github.com/proudcity/intuitive-custom-post-order/pull/1)
- Adds a checkbox to check whether hijiriworld#64 landed in a post-3.2.0 release (if so, we can drop the fork and pull upstream directly)
- Adds the verification method (diff fork PHP file vs pristine upstream — should show only the three flush lines)

Section heading left as-is (preserving existing "Inuitive" typo to avoid churn).

Refs #2854